### PR TITLE
Inflate speedup

### DIFF
--- a/src/huffman.ts
+++ b/src/huffman.ts
@@ -1,21 +1,26 @@
-export function generateHuffmanTable(codelenValues: Map<number, number[]>): {[key: number]: {[key: number]: number}} {
-  const codelens = codelenValues.keys();
-  let iteratorResult = codelens.next();
+export interface ICodelenValues {
+  [key: number]: number[];
+}
+export interface IHuffmanTable {
+  [key: number]: {[key: number]: number};
+}
+
+export function generateHuffmanTable(codelenValues: ICodelenValues): IHuffmanTable {
+  const codelens = Object.keys(codelenValues);
   let codelen = 0;
   let codelenMax = 0;
   let codelenMin = Number.MAX_SAFE_INTEGER;
-  while (!iteratorResult.done) {
-    codelen = iteratorResult.value;
+  codelens.forEach((key) => {
+    codelen = Number(key);
     if (codelenMax < codelen) { codelenMax = codelen; }
     if (codelenMin > codelen) { codelenMin = codelen; }
-    iteratorResult = codelens.next();
-  }
+  });
 
   let code = 0;
   let values: number[];
-  const bitlenTables: {[key: number]: {[key: number]: number}} = {};
+  const bitlenTables: IHuffmanTable = {};
   for (let bitlen = codelenMin; bitlen <= codelenMax; bitlen++) {
-    values = codelenValues.get(bitlen) as number[];
+    values = codelenValues[bitlen];
     if (values === undefined) { values = []; }
     values.sort((a, b) => {
       if ( a < b ) { return -1; }
@@ -33,16 +38,16 @@ export function generateHuffmanTable(codelenValues: Map<number, number[]>): {[ke
   return bitlenTables;
 }
 
-export function makeFixedHuffmanCodelenValues(): Map<number, number[]> {
-  const codelenValues = new Map();
-  codelenValues.set(7, new Array());
-  codelenValues.set(8, new Array());
-  codelenValues.set(9, new Array());
+export function makeFixedHuffmanCodelenValues(): ICodelenValues {
+  const codelenValues: ICodelenValues = {};
+  codelenValues[7] = [];
+  codelenValues[8] = [];
+  codelenValues[9] = [];
   for (let i = 0; i <= 287; i++) {
-    (i <= 143) ? codelenValues.get(8).push(i) :
-    (i <= 255) ? codelenValues.get(9).push(i) :
-    (i <= 279) ? codelenValues.get(7).push(i) :
-    codelenValues.get(8).push(i);
+    (i <= 143) ? codelenValues[8].push(i) :
+    (i <= 255) ? codelenValues[9].push(i) :
+    (i <= 279) ? codelenValues[7].push(i) :
+    codelenValues[8].push(i);
   }
   return codelenValues;
 }

--- a/src/huffman.ts
+++ b/src/huffman.ts
@@ -1,4 +1,4 @@
-export function generateHuffmanTable(codelenValues: Map<number, number[]>): Map<number, Map<number, number>> {
+export function generateHuffmanTable(codelenValues: Map<number, number[]>): {[key: number]: {[key: number]: number}} {
   const codelens = codelenValues.keys();
   let iteratorResult = codelens.next();
   let codelen = 0;
@@ -13,7 +13,7 @@ export function generateHuffmanTable(codelenValues: Map<number, number[]>): Map<
 
   let code = 0;
   let values: number[];
-  const bitlenTables = new Map();
+  const bitlenTables: {[key: number]: {[key: number]: number}} = {};
   for (let bitlen = codelenMin; bitlen <= codelenMax; bitlen++) {
     values = codelenValues.get(bitlen) as number[];
     if (values === undefined) { values = []; }
@@ -22,12 +22,12 @@ export function generateHuffmanTable(codelenValues: Map<number, number[]>): Map<
       if ( a > b ) { return 1; }
       return 0;
     });
-    const table = new Map();
+    const table: {[key: number]: number} = {};
     values.forEach((value) => {
-      table.set(code, value);
+      table[code] = value;
       code++;
     });
-    bitlenTables.set(bitlen, table);
+    bitlenTables[bitlen] = table;
     code <<= 1;
   }
   return bitlenTables;

--- a/src/inflate.ts
+++ b/src/inflate.ts
@@ -7,7 +7,7 @@ import {
   LENGTH_EXTRA_BIT_BASE,
   LENGTH_EXTRA_BIT_LEN,
 } from './const';
-import {generateHuffmanTable, makeFixedHuffmanCodelenValues} from './huffman';
+import {generateHuffmanTable, ICodelenValues, makeFixedHuffmanCodelenValues} from './huffman';
 import {BitReadStream} from './utils/BitReadStream';
 import {Uint8WriteStream} from './utils/Uint8WriteStream';
 
@@ -125,16 +125,16 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
   const HCLEN = stream.readRange(4) + 4;
 
   let codelenCodelen = 0;
-  const codelenCodelenValues = new Map();
+  const codelenCodelenValues: ICodelenValues = {};
   for (let i = 0; i < HCLEN; i++) {
     codelenCodelen = stream.readRange(3);
     if (codelenCodelen === 0) {
       continue;
     }
-    if (!codelenCodelenValues.has(codelenCodelen)) {
-      codelenCodelenValues.set(codelenCodelen, new Array());
+    if (!codelenCodelenValues[codelenCodelen]) {
+      codelenCodelenValues[codelenCodelen] = [];
     }
-    codelenCodelenValues.get(codelenCodelen).push(CODELEN_VALUES[i]);
+    codelenCodelenValues[codelenCodelen].push(CODELEN_VALUES[i]);
   }
   const codelenHuffmanTables = generateHuffmanTable(codelenCodelenValues);
 
@@ -147,8 +147,8 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
     if (codelenCodelenMin > codelenCodelen) { codelenCodelenMin = codelenCodelen; }
   });
 
-  const dataCodelenValues = new Map();
-  const distanceCodelenValues = new Map();
+  const dataCodelenValues: ICodelenValues = {};
+  const distanceCodelenValues: ICodelenValues = {};
   let codelenCode = 0;
   let codelenHuffmanTable;
   let runlengthCode;
@@ -191,15 +191,15 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
         break;
       }
       if (i < HLIT) {
-        if (!dataCodelenValues.has(codelen)) {
-          dataCodelenValues.set(codelen, new Array());
+        if (!dataCodelenValues[codelen]) {
+          dataCodelenValues[codelen] = [];
         }
-        dataCodelenValues.get(codelen).push(i++);
+        dataCodelenValues[codelen].push(i++);
       } else {
-        if (!distanceCodelenValues.has(codelen)) {
-          distanceCodelenValues.set(codelen, new Array());
+        if (!distanceCodelenValues[codelen]) {
+          distanceCodelenValues[codelen] = [];
         }
-        distanceCodelenValues.get(codelen).push(i++ - HLIT);
+        distanceCodelenValues[codelen].push(i++ - HLIT);
       }
       repeat--;
     }

--- a/src/inflate.ts
+++ b/src/inflate.ts
@@ -57,17 +57,15 @@ function inflateUncompressedBlock(stream: BitReadStream, buffer: Uint8WriteStrea
 function inflateFixedBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
   const tables = FIXED_HUFFMAN_TABLE;
 
-  const codelens = tables.keys();
-  let iteratorResult = codelens.next();
+  const codelens = Object.keys(tables);
   let codelen = 0;
   let codelenMax = 0;
   let codelenMin = Number.MAX_SAFE_INTEGER;
-  while (!iteratorResult.done) {
-    codelen = iteratorResult.value;
+  codelens.forEach((key) => {
+    codelen = Number(key);
     if (codelenMax < codelen) { codelenMax = codelen; }
     if (codelenMin > codelen) { codelenMin = codelen; }
-    iteratorResult = codelens.next();
-  }
+  });
   let code = 0;
   let table;
   let value;
@@ -83,10 +81,10 @@ function inflateFixedBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
     codelen = codelenMin;
     code = stream.readRangeCoded(codelenMin - 1);
     while (codelen <= codelenMax) {
-      table = tables.get(codelen) as Map<number, number>;
+      table = tables[codelen];
       code <<= 1;
       code |= stream.read();
-      value = table.get(code);
+      value = table[code];
       if (value !== undefined) {
         break;
       }
@@ -140,16 +138,14 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
   }
   const codelenHuffmanTables = generateHuffmanTable(codelenCodelenValues);
 
-  const codelenCodelens = codelenHuffmanTables.keys();
-  let codelenCodelensIteratorResult = codelenCodelens.next();
+  const codelenCodelens = Object.keys(codelenHuffmanTables);
   let codelenCodelenMax = 0;
   let codelenCodelenMin = Number.MAX_SAFE_INTEGER;
-  while (!codelenCodelensIteratorResult.done) {
-    codelenCodelen = codelenCodelensIteratorResult.value;
+  codelenCodelens.forEach((key) => {
+    codelenCodelen = Number(key);
     if (codelenCodelenMax < codelenCodelen) { codelenCodelenMax = codelenCodelen; }
     if (codelenCodelenMin > codelenCodelen) { codelenCodelenMin = codelenCodelen; }
-    codelenCodelensIteratorResult = codelenCodelens.next();
-  }
+  });
 
   const dataCodelenValues = new Map();
   const distanceCodelenValues = new Map();
@@ -165,10 +161,10 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
     codelenCodelen = codelenCodelenMin;
     codelenCode = stream.readRangeCoded(codelenCodelenMin - 1);
     while (codelenCodelen <= codelenCodelenMax) {
-      codelenHuffmanTable = codelenHuffmanTables.get(codelenCodelen) as Map<number, number>;
+      codelenHuffmanTable = codelenHuffmanTables[codelenCodelen];
       codelenCode <<= 1;
       codelenCode |= stream.read();
-      runlengthCode = codelenHuffmanTable.get(codelenCode);
+      runlengthCode = codelenHuffmanTable[codelenCode];
       if (runlengthCode !== undefined) {
         break;
       }
@@ -211,29 +207,25 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
   const dataHuffmanTables = generateHuffmanTable(dataCodelenValues);
   const distanceHuffmanTables = generateHuffmanTable(distanceCodelenValues);
 
-  const dataCodelens = dataHuffmanTables.keys();
-  let dataCodelensIteratorResult = dataCodelens.next();
+  const dataCodelens = Object.keys(dataHuffmanTables);
   let dataCodelen = 0;
   let dataCodelenMax = 0;
   let dataCodelenMin = Number.MAX_SAFE_INTEGER;
-  while (!dataCodelensIteratorResult.done) {
-    dataCodelen = dataCodelensIteratorResult.value;
+  dataCodelens.forEach((key) => {
+    dataCodelen = Number(key);
     if (dataCodelenMax < dataCodelen) { dataCodelenMax = dataCodelen; }
     if (dataCodelenMin > dataCodelen) { dataCodelenMin = dataCodelen; }
-    dataCodelensIteratorResult = dataCodelens.next();
-  }
+  });
 
-  const distanceCodelens = distanceHuffmanTables.keys();
-  let distanceCodelensIteratorResult = distanceCodelens.next();
+  const distanceCodelens = Object.keys(distanceHuffmanTables);
   let distanceCodelen = 0;
   let distanceCodelenMax = 0;
   let distanceCodelenMin = Number.MAX_SAFE_INTEGER;
-  while (!distanceCodelensIteratorResult.done) {
-    distanceCodelen = distanceCodelensIteratorResult.value;
+  distanceCodelens.forEach((key) => {
+    distanceCodelen = Number(key);
     if (distanceCodelenMax < distanceCodelen) { distanceCodelenMax = distanceCodelen; }
     if (distanceCodelenMin > distanceCodelen) { distanceCodelenMin = distanceCodelen; }
-    distanceCodelensIteratorResult = distanceCodelens.next();
-  }
+  });
 
   let dataCode = 0;
   let dataHuffmanTable;
@@ -253,10 +245,10 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
     dataCodelen = dataCodelenMin;
     dataCode = stream.readRangeCoded(dataCodelenMin - 1);
     while (dataCodelen <= dataCodelenMax) {
-      dataHuffmanTable = dataHuffmanTables.get(dataCodelen) as Map<number, number>;
+      dataHuffmanTable = dataHuffmanTables[dataCodelen];
       dataCode <<= 1;
       dataCode |= stream.read();
-      data = dataHuffmanTable.get(dataCode);
+      data = dataHuffmanTable[dataCode];
       if (data !== undefined) {
         break;
       }
@@ -283,10 +275,10 @@ function inflateDynamicBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
     repeatDistanceCodeCodelen = distanceCodelenMin;
     repeatDistanceCodeCode = stream.readRangeCoded(distanceCodelenMin - 1);
     while (repeatDistanceCodeCodelen <= distanceCodelenMax) {
-      distanceHuffmanTable = distanceHuffmanTables.get(repeatDistanceCodeCodelen) as Map<number, number>;
+      distanceHuffmanTable = distanceHuffmanTables[repeatDistanceCodeCodelen];
       repeatDistanceCodeCode <<= 1;
       repeatDistanceCodeCode |= stream.read();
-      repeatDistanceCode = distanceHuffmanTable.get(repeatDistanceCodeCode);
+      repeatDistanceCode = distanceHuffmanTable[repeatDistanceCodeCode];
       if (repeatDistanceCode !== undefined) {
         break;
       }


### PR DESCRIPTION
Improve inflate speed.
Speed is measured by binary data test.

### Change the inflate table from Map to Object https://github.com/zprodev/zlib.es/pull/1/commits/75deef6e6d4f173fd86a0889c37a2c217f6d62b0

|No.|before|after|
|:---:|---:|---:|
|1|147ms|130ms|
|2|159ms|127ms|
|3|152ms|121ms|
|4|156ms|120ms|
|5|155ms|125ms|

### Change the inflate CodelenValues from Map to Object https://github.com/zprodev/zlib.es/pull/1/commits/173fe0d6b8e8d9e4c1c67078b2b4130da1aa0b34

|No.|after|
|:---:|---:|
|1|103ms|
|2|103ms|
|3|102ms|
|4|109ms|
|5|106ms|

### Refactor of iterative processing https://github.com/zprodev/zlib.es/pull/1/commits/6fe4e090e0c3ffcb525bde9e38a38ae67f5d647d

|No.|after|
|:---:|---:|
|1|99ms|
|2|101ms|
|3|109ms|
|4|107ms|
|5|103ms|



