### PR TITLE
Deflate speed up

### DIFF
--- a/src/deflate.ts
+++ b/src/deflate.ts
@@ -172,10 +172,10 @@ function deflateDynamicBlock(stream: BitWriteStream, input: Uint8Array) {
       nowIndex++;
       continue;
     }
-    indexes.forEach((hidIndex) => {
-      if (slideIndexBase <= hidIndex && hidIndex < nowIndex ) {
+    for (let i = 0, iMax = indexes.length; i < iMax; i++) {
+      if (slideIndexBase <= indexes[i] && indexes[i] < nowIndex ) {
         repeatLength = 0;
-        while (input[hidIndex + repeatLength] === input[nowIndex + repeatLength]) {
+        while (input[indexes[i] + repeatLength] === input[nowIndex + repeatLength]) {
           repeatLength++;
           if (257 < repeatLength) {
             break;
@@ -183,10 +183,10 @@ function deflateDynamicBlock(stream: BitWriteStream, input: Uint8Array) {
         }
         if (repeatLengthMax < repeatLength) {
           repeatLengthMax = repeatLength;
-          repeatLengthMaxIndex = hidIndex;
+          repeatLengthMaxIndex = indexes[i];
         }
       }
-    });
+    }
     if (repeatLengthMax >= 3) {
       distance = nowIndex - repeatLengthMaxIndex;
       for (let i = 0; i < LENGTH_EXTRA_BIT_BASE.length; i++) {

--- a/src/lz77.ts
+++ b/src/lz77.ts
@@ -3,12 +3,26 @@ import {
   LENGTH_EXTRA_BIT_BASE,
 } from './const';
 
-export function generateLZ77CodeValues(input: Uint8Array) {
+export const REPEAT_LEN_MIN = 3;
+
+export function generateLZ77IndexMap(input: Uint8Array) {
+  const end = input.length - REPEAT_LEN_MIN;
+  const indexMap: {[key: number]: number[]} = {};
+  for (let i = 0; i <= end; i++) {
+    const indexKey = input[i] << 16 | input[i + 1] << 8 | input[i + 2];
+    if (indexMap[indexKey] === undefined) {
+      indexMap[indexKey] = [];
+    }
+    indexMap[indexKey].push(i);
+  }
+  return indexMap;
+}
+
+export function generateLZ77CodeValues(input: Uint8Array, indexMap: {[key: number]: number[]}) {
   const lengthCodeValues: number[] = [256];
   const distanceCodeValues: number[] = [];
   const inputLen = input.length;
   let slideIndexBase = 0;
-  let slideIndex = 0;
   let nowIndex = 0;
   let repeatLength = 0;
   let repeatLengthMax = 0;
@@ -21,23 +35,32 @@ export function generateLZ77CodeValues(input: Uint8Array) {
 
   while (nowIndex < inputLen) {
     slideIndexBase = (nowIndex > 0x8000) ? nowIndex - 0x8000 : 0 ;
-    slideIndex = 0;
     repeatLength = 0;
     repeatLengthMax = 0;
-    while (slideIndexBase + slideIndex < nowIndex) {
-      repeatLength = 0;
-      while (input[slideIndexBase + slideIndex + repeatLength] === input[nowIndex + repeatLength]) {
-        repeatLength++;
-        if (257 < repeatLength) {
-          break;
+
+    const indexes = indexMap[
+      input[nowIndex] << 16 | input[nowIndex + 1] << 8 | input[nowIndex + 2]
+    ];
+    if (indexes === undefined) {
+      lengthCodeValues.push(input[nowIndex]);
+      nowIndex++;
+      continue;
+    }
+    indexes.forEach((hidIndex) => {
+      if (slideIndexBase <= hidIndex && hidIndex < nowIndex ) {
+        repeatLength = 0;
+        while (input[hidIndex + repeatLength] === input[nowIndex + repeatLength]) {
+          repeatLength++;
+          if (257 < repeatLength) {
+            break;
+          }
+        }
+        if (repeatLengthMax < repeatLength) {
+          repeatLengthMax = repeatLength;
+          repeatLengthMaxIndex = hidIndex;
         }
       }
-      if (repeatLengthMax < repeatLength) {
-        repeatLengthMax = repeatLength;
-        repeatLengthMaxIndex = slideIndexBase + slideIndex;
-      }
-      slideIndex++;
-    }
+    });
     if (repeatLengthMax >= 3) {
       distance = nowIndex - repeatLengthMaxIndex;
       for (let i = 0; i < LENGTH_EXTRA_BIT_BASE.length; i++) {

--- a/src/lz77.ts
+++ b/src/lz77.ts
@@ -46,10 +46,11 @@ export function generateLZ77CodeValues(input: Uint8Array, indexMap: {[key: numbe
       nowIndex++;
       continue;
     }
-    indexes.forEach((hidIndex) => {
-      if (slideIndexBase <= hidIndex && hidIndex < nowIndex ) {
+
+    for (let i = 0, iMax = indexes.length; i < iMax; i++) {
+      if (slideIndexBase <= indexes[i] && indexes[i] < nowIndex ) {
         repeatLength = 0;
-        while (input[hidIndex + repeatLength] === input[nowIndex + repeatLength]) {
+        while (input[indexes[i] + repeatLength] === input[nowIndex + repeatLength]) {
           repeatLength++;
           if (257 < repeatLength) {
             break;
@@ -57,10 +58,10 @@ export function generateLZ77CodeValues(input: Uint8Array, indexMap: {[key: numbe
         }
         if (repeatLengthMax < repeatLength) {
           repeatLengthMax = repeatLength;
-          repeatLengthMaxIndex = hidIndex;
+          repeatLengthMaxIndex = indexes[i];
         }
       }
-    });
+    }
     if (repeatLengthMax >= 3) {
       distance = nowIndex - repeatLengthMaxIndex;
       for (let i = 0; i < LENGTH_EXTRA_BIT_BASE.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -43,40 +43,68 @@ describe('inflate', function() {
 });
 
 describe('deflate', function() {
-  describe('RAW', function() {
-    const deflateOutput = zlibes.deflate(RAW);
-    it('zlib.es', function() {
-      assert.deepEqual(
-        RAW,
-        zlibes.inflate(deflateOutput)
-      );
+  describe('Execution', function() {
+    it('RAW', function() {
+      zlibes.deflate(RAW);
+      assert.ok(true);
     });
-    it('Node.js zlib', function() {
-      assert.deepEqual(
-        RAW,
-        nodeZlib.inflateSync(deflateOutput)
-      );
+    it('binary data', function() {
+      zlibes.deflate(RAW_BIN);
+      assert.ok(true);
     });
   });
-  describe('Repeat Length Limit', function() {
-    const ascii = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-    let asciiRepeat = '';
-    while(asciiRepeat.length < 1000){
-      asciiRepeat += ascii;
-    }
-    const deflateInput = new Uint8Array(new Buffer(asciiRepeat));
-    const deflateOutput = zlibes.deflate(deflateInput);
-    it('zlib.es', function() {
-      assert.deepEqual(
-        deflateInput,
-        zlibes.inflate(deflateOutput)
-      );
+  describe('Validation', function() {
+    describe('RAW', function() {
+      const deflateOutput = zlibes.deflate(RAW);
+      it('zlib.es', function() {
+        assert.deepEqual(
+          RAW,
+          zlibes.inflate(deflateOutput)
+        );
+      });
+      it('Node.js', function() {
+        assert.deepEqual(
+          RAW,
+          nodeZlib.inflateSync(deflateOutput)
+        );
+      });
     });
-    it('Node.js zlib', function() {
-      assert.deepEqual(
-        deflateInput,
-        nodeZlib.inflateSync(deflateOutput)
-      );
+    describe('binary data', function() {
+      const deflateOutput = zlibes.deflate(RAW_BIN);
+      it('zlib.es', function() {
+        assert.deepEqual(
+          RAW_BIN,
+          zlibes.inflate(deflateOutput)
+        );
+      });
+      it('Node.js', function() {
+        assert.deepEqual(
+          RAW_BIN,
+          nodeZlib.inflateSync(deflateOutput)
+        );
+      });
+    });
+  
+    describe('Repeat Length Limit', function() {
+      const ascii = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+      let asciiRepeat = '';
+      while(asciiRepeat.length < 1000){
+        asciiRepeat += ascii;
+      }
+      const deflateInput = new Uint8Array(new Buffer(asciiRepeat));
+      const deflateOutput = zlibes.deflate(deflateInput);
+      it('zlib.es', function() {
+        assert.deepEqual(
+          deflateInput,
+          zlibes.inflate(deflateOutput)
+        );
+      });
+      it('Node.js', function() {
+        assert.deepEqual(
+          deflateInput,
+          nodeZlib.inflateSync(deflateOutput)
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Improve deflate speed.
Speed is measured by binary data test.

### Changed LZ77 algorithm to Index search https://github.com/zprodev/zlib.es/pull/3/commits/86d6642cdbbdcd4dc34dfa6de694fc58b1ef6bc9

|No.|before|after|
|:---:|---:|---:|
|1|35379 ms|18914 ms|
|2|35141 ms|19090 ms|
|3|35515 ms|18949 ms|
|4|35428 ms|19007 ms|
|5|35485 ms|19019 ms|

### Changed huge repeating foreach to for https://github.com/zprodev/zlib.es/pull/3/commits/0728c08521c179805488d686e8ffd068fb686b60

|No.|after|
|:---:|---:|
|1|5436 ms|
|2|5427 ms|
|3|5141 ms|
|4|5305 ms|
|5|5945 ms|

### Reduce lz77 search https://github.com/zprodev/zlib.es/pull/3/commits/c518f9e35140c44ec8031c241b834bbb7331630b

|No.|after|
|:---:|---:|
|1|875 ms|
|2|913 ms|
|3|913 ms|
|4|896 ms|
|5|925 ms|
