### PR TITLE
Deflate speed up 2

### DIFF
--- a/src/lz77.ts
+++ b/src/lz77.ts
@@ -29,7 +29,8 @@ export function generateLZ77Codes(input: Uint8Array) {
   let repeatLengthCodeValue = 0;
   let repeatDistanceCodeValue = 0;
   const codeTargetValues = [];
-  const skipIndexMap: {[key: number]: number} = {};
+  const startIndexMap: {[key: number]: number} = {};
+  const endIndexMap: {[key: number]: number} = {};
   const indexMap = generateLZ77IndexMap(input);
   while (nowIndex < inputLen) {
     const indexKey = input[nowIndex] << 16 | input[nowIndex + 1] << 8 | input[nowIndex + 2];
@@ -44,31 +45,40 @@ export function generateLZ77Codes(input: Uint8Array) {
     slideIndexBase = (nowIndex > 0x8000) ? nowIndex - 0x8000 : 0 ;
     repeatLengthMax = 0;
     repeatLengthMaxIndex = 0;
-    indexMapLoop: for (let i = skipIndexMap[indexKey] || 0, iMax = indexes.length; i < iMax; i++) {
+
+    let skipindexes = startIndexMap[indexKey] || 0;
+    while(indexes[skipindexes] < slideIndexBase){
+      skipindexes = (skipindexes + 1) | 0;
+    }
+    startIndexMap[indexKey] = skipindexes;
+    skipindexes = endIndexMap[indexKey] || 0;
+    while(indexes[skipindexes] < nowIndex){
+      skipindexes = (skipindexes + 1) | 0;
+    }
+    endIndexMap[indexKey] = skipindexes;
+
+    indexMapLoop: for (let i = endIndexMap[indexKey] - 1, iMin = startIndexMap[indexKey]; iMin <= i; i--) {
       const index = indexes[i];
-      if (nowIndex <= index) {
-        break;
-      }
-      if (index < slideIndexBase) {
-        skipIndexMap[indexKey] = i + 1;
-        continue;
-      }
       for (let j = repeatLengthMax - 1; 0 < j; j--) {
         if (input[index + j] !== input[nowIndex + j]) {
           continue indexMapLoop;
         }
       }
-      repeatLength = repeatLengthMax;
-      while (input[index + repeatLength] === input[nowIndex + repeatLength]) {
-        repeatLength++;
-        if (257 < repeatLength) {
-          repeatLength = 258;
+
+      repeatLength = 258;
+
+      for (let j = repeatLengthMax; j <= 258; j++) {
+        if (input[index + j] !== input[nowIndex + j]) {
+          repeatLength = j;
           break;
         }
       }
-      if (repeatLengthMax <= repeatLength) {
+      if (repeatLengthMax < repeatLength) {
         repeatLengthMax = repeatLength;
         repeatLengthMaxIndex = index;
+        if(258 <= repeatLength){
+          break;
+        }
       }
     }
     if (repeatLengthMax >= 3) {


### PR DESCRIPTION
Improve deflate speed.
For the measurement, image data of 4 MB is used.

### Start LZ77 search from the end

|No.|before|after|
|:---:|---:|---:|
|1|19574 ms|3839 ms|
|2|19130 ms|3809 ms|
|3|19254 ms|3911 ms|
|4|19222 ms|3796 ms|
|5|19254 ms|3826 ms|
