### PR TITLE
Feature/inflate speedup2

### DIFF
--- a/src/inflate.ts
+++ b/src/inflate.ts
@@ -14,7 +14,7 @@ import {Uint8WriteStream} from './utils/Uint8WriteStream';
 const FIXED_HUFFMAN_TABLE = generateHuffmanTable( makeFixedHuffmanCodelenValues() );
 
 export function inflate(input: Uint8Array, offset: number = 0) {
-  const buffer = new Uint8WriteStream(BLOCK_MAX_BUFFER_LEN);
+  const buffer = new Uint8WriteStream(input.length * 10);
 
   const stream = new BitReadStream(input, offset);
   let bFinal = 0;

--- a/src/inflate.ts
+++ b/src/inflate.ts
@@ -41,8 +41,8 @@ export function inflate(input: Uint8Array, offset: number = 0) {
 
 function inflateUncompressedBlock(stream: BitReadStream, buffer: Uint8WriteStream) {
   // Skip to byte boundary
-  if (stream.nowBitsIndex > 0) {
-    stream.readRange(8 - stream.nowBitsIndex);
+  if (stream.nowBitsLength < 8) {
+    stream.readRange(stream.nowBitsLength);
   }
   const LEN = stream.readRange(8) | stream.readRange(8) << 8;
   const NLEN = stream.readRange(8) | stream.readRange(8) << 8;

--- a/src/utils/BitReadStream.ts
+++ b/src/utils/BitReadStream.ts
@@ -2,36 +2,41 @@ export class BitReadStream {
   public buffer: Uint8Array;
   public bufferIndex: number;
   public nowBits: number;
-  public nowBitsIndex = 0;
+  public nowBitsLength = 0;
   public isEnd = false;
   constructor(buffer: Uint8Array, offset: number = 0) {
     this.buffer = buffer;
     this.bufferIndex = offset;
     this.nowBits = buffer[offset];
+    this.nowBitsLength = 8;
   }
 
   public read() {
     if (this.isEnd) { throw new Error('Lack of data length'); }
     const bit = this.nowBits & 1;
-    if (this.nowBitsIndex < 7) {
-      this.nowBitsIndex++;
+    if (this.nowBitsLength > 1) {
+      this.nowBitsLength--;
       this.nowBits >>= 1;
     } else {
       this.bufferIndex++;
-      this.nowBitsIndex = 0;
       if (this.bufferIndex < this.buffer.length) {
         this.nowBits = this.buffer[this.bufferIndex];
+        this.nowBitsLength = 8;
       } else {
+        this.nowBitsLength = 0;
         this.isEnd = true;
       }
     }
     return bit;
   }
   public readRange(length: number) {
-    let bits = 0;
-    for (let i = 0; i < length; i++) {
-      bits |= this.read() << i;
+    while (this.nowBitsLength <= length) {
+      this.nowBits |= this.buffer[++this.bufferIndex] << this.nowBitsLength;
+      this.nowBitsLength += 8;
     }
+    const bits = this.nowBits & ((1 << length) - 1);
+    this.nowBits >>>= length;
+    this.nowBitsLength -= length;
     return bits;
   }
   public readRangeCoded(length: number) {


### PR DESCRIPTION
Improve inflate speed.
Test with PNG data 4096 x 4096 (8.2 MB)

### Resuce memory expansion https://github.com/zprodev/zlib.es/commit/b35157dce5c9d2a8fef91cca79a2c0cd14c092d6

|No.|before|after|
|:---:|---:|---:|
|1|28362 ms|1397 ms|
|2|27921 ms|1391 ms|
|3|28546 ms|1363 ms|
|4|28888 ms|1397 ms|
|5|28702 ms|1374 ms|

### Improve bit reading https://github.com/zprodev/zlib.es/commit/7d3e15f6ee5224a9628ea2926a7e177b045933c5

|No.|after|
|:---:|---:|
|1|1267 ms|
|2|1350 ms|
|3|1227 ms|
|4|1259 ms|
|5|1235 ms|
