### PR TITLE
Deflate speedup3

### DIFF
--- a/src/huffman.ts
+++ b/src/huffman.ts
@@ -52,7 +52,10 @@ export function makeFixedHuffmanCodelenValues(): ICodelenValues {
   return codelenValues;
 }
 
-export function generateDeflateHuffmanTable(values: number[]): Map<number, {code: number, bitlen: number}> {
+export function generateDeflateHuffmanTable(
+  values: number[],
+  maxLength: number = 15,
+  ): Map<number, {code: number, bitlen: number}> {
   const valuesCount: {[key: number]: number} = {};
   for (const value of values) {
     if (!valuesCount[value]) {
@@ -71,7 +74,7 @@ export function generateDeflateHuffmanTable(values: number[]): Map<number, {code
       simbles: [Number(valuesCountKeys[0])],
     });
   } else {
-    for (let i = 0; i < 15; i++) {
+    for (let i = 0; i < maxLength; i++) {
       packages = [];
       valuesCountKeys.forEach((value) => {
         const pack = {

--- a/src/lz77.ts
+++ b/src/lz77.ts
@@ -3,7 +3,10 @@ import {
   LENGTH_EXTRA_BIT_BASE,
 } from './const';
 
-export const REPEAT_LEN_MIN = 3;
+const REPEAT_LEN_MIN = 3;
+const FAST_INDEX_CHECK_MAX = 128;
+const FAST_INDEX_CHECK_MIN = 16;
+const FAST_REPEAT_LENGTH = 8;
 
 function generateLZ77IndexMap(input: Uint8Array) {
   const end = input.length - REPEAT_LEN_MIN;
@@ -57,7 +60,13 @@ export function generateLZ77Codes(input: Uint8Array) {
     }
     endIndexMap[indexKey] = skipindexes;
 
+    let checkCount = 0;
     indexMapLoop: for (let i = endIndexMap[indexKey] - 1, iMin = startIndexMap[indexKey]; iMin <= i; i--) {
+      if (checkCount >= FAST_INDEX_CHECK_MAX
+        || (repeatLengthMax >= FAST_REPEAT_LENGTH && checkCount >= FAST_INDEX_CHECK_MIN)) {
+        break;
+      }
+      ++checkCount;
       const index = indexes[i];
       for (let j = repeatLengthMax - 1; 0 < j; j--) {
         if (input[index + j] !== input[nowIndex + j]) {

--- a/src/lz77.ts
+++ b/src/lz77.ts
@@ -8,10 +8,10 @@ const FAST_INDEX_CHECK_MAX = 128;
 const FAST_INDEX_CHECK_MIN = 16;
 const FAST_REPEAT_LENGTH = 8;
 
-function generateLZ77IndexMap(input: Uint8Array) {
-  const end = input.length - REPEAT_LEN_MIN;
+function generateLZ77IndexMap(input: Uint8Array, startIndex: number, targetLength: number) {
+  const end = startIndex + targetLength - REPEAT_LEN_MIN;
   const indexMap: {[key: number]: number[]} = {};
-  for (let i = 0; i <= end; i++) {
+  for (let i = startIndex; i <= end; i++) {
     const indexKey = input[i] << 16 | input[i + 1] << 8 | input[i + 2];
     if (indexMap[indexKey] === undefined) {
       indexMap[indexKey] = [];
@@ -21,9 +21,9 @@ function generateLZ77IndexMap(input: Uint8Array) {
   return indexMap;
 }
 
-export function generateLZ77Codes(input: Uint8Array) {
-  const inputLen = input.length;
-  let nowIndex = 0;
+export function generateLZ77Codes(input: Uint8Array, startIndex: number, targetLength: number) {
+  let nowIndex = startIndex;
+  const endIndex = startIndex + targetLength - REPEAT_LEN_MIN;
   let slideIndexBase = 0;
   let repeatLength = 0;
   let repeatLengthMax = 0;
@@ -34,8 +34,9 @@ export function generateLZ77Codes(input: Uint8Array) {
   const codeTargetValues = [];
   const startIndexMap: {[key: number]: number} = {};
   const endIndexMap: {[key: number]: number} = {};
-  const indexMap = generateLZ77IndexMap(input);
-  while (nowIndex < inputLen) {
+  const indexMap = generateLZ77IndexMap(input, startIndex, targetLength);
+
+  while (nowIndex <= endIndex) {
     const indexKey = input[nowIndex] << 16 | input[nowIndex + 1] << 8 | input[nowIndex + 2];
     const indexes = indexMap[
       indexKey
@@ -66,7 +67,7 @@ export function generateLZ77Codes(input: Uint8Array) {
         || (repeatLengthMax >= FAST_REPEAT_LENGTH && checkCount >= FAST_INDEX_CHECK_MIN)) {
         break;
       }
-      ++checkCount;
+      checkCount++;
       const index = indexes[i];
       for (let j = repeatLengthMax - 1; 0 < j; j--) {
         if (input[index + j] !== input[nowIndex + j]) {
@@ -90,7 +91,8 @@ export function generateLZ77Codes(input: Uint8Array) {
         }
       }
     }
-    if (repeatLengthMax >= 3) {
+
+    if (repeatLengthMax >= 3 && nowIndex + repeatLengthMax <= endIndex) {
       distance = nowIndex - repeatLengthMaxIndex;
       for (let i = 0; i < LENGTH_EXTRA_BIT_BASE.length; i++) {
         if (LENGTH_EXTRA_BIT_BASE[i] > repeatLengthMax) {
@@ -111,5 +113,7 @@ export function generateLZ77Codes(input: Uint8Array) {
       nowIndex++;
     }
   }
+  codeTargetValues.push([input[nowIndex]]);
+  codeTargetValues.push([input[nowIndex + 1]]);
   return codeTargetValues;
 }


### PR DESCRIPTION
Improve deflate speed.
For the measurement, image data of 50 MB is used.

### Restrict loops to speed up https://github.com/zprodev/zlib.es/commit/218afcfe105074a8345bcb312315fb71edc7bc23

|No.|before|after|
|:---:|---:|---:|
|1| Unmeasurable|18488 ms|
|2| Unmeasurable|18605 ms|
|3| Unmeasurable|19456 ms|
|4| Unmeasurable|19019 ms|
|5| Unmeasurable|18501 ms|

### Split compression https://github.com/zprodev/zlib.es/commit/fcbf3d1529f51e83a8fb27c254d036e7e5c1da65

|No.|after|
|:---:|---:|
|1|13447 ms|
|2|13413 ms|
|3|13477 ms|
|4|13569 ms|
|5|13923 ms|
